### PR TITLE
Update for newer RN and React

### DIFF
--- a/VoiceTest/android/app/src/main/AndroidManifest.xml
+++ b/VoiceTest/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:targetSdkVersion="22" />
 
     <application
+      android:name=".MainApplication"
       android:allowBackup="true"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"

--- a/VoiceTest/android/app/src/main/java/com/voicetest/MainActivity.java
+++ b/VoiceTest/android/app/src/main/java/com/voicetest/MainActivity.java
@@ -1,12 +1,6 @@
 package com.voicetest;
 
 import com.facebook.react.ReactActivity;
-import com.facebook.react.ReactPackage;
-import com.facebook.react.shell.MainReactPackage;
-import com.wenkesj.voice.VoicePackage;
-
-import java.util.Arrays;
-import java.util.List;
 
 public class MainActivity extends ReactActivity {
 
@@ -17,26 +11,5 @@ public class MainActivity extends ReactActivity {
     @Override
     protected String getMainComponentName() {
         return "VoiceTest";
-    }
-
-    /**
-     * Returns whether dev mode should be enabled.
-     * This enables e.g. the dev menu.
-     */
-    @Override
-    protected boolean getUseDeveloperSupport() {
-        return BuildConfig.DEBUG;
-    }
-
-    /**
-     * A list of packages used by the app. If the app uses additional views
-     * or modules besides the default ones, add more packages here.
-     */
-    @Override
-    protected List<ReactPackage> getPackages() {
-        return Arrays.<ReactPackage>asList(
-            new MainReactPackage(),
-            new VoicePackage()
-        );
     }
 }

--- a/VoiceTest/android/app/src/main/java/com/voicetest/MainApplication.java
+++ b/VoiceTest/android/app/src/main/java/com/voicetest/MainApplication.java
@@ -1,0 +1,47 @@
+package com.voicetest;
+
+import android.app.Application;
+import android.util.Log;
+
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.shell.MainReactPackage;
+
+import com.wenkesj.voice.VoicePackage;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class MainApplication extends Application implements ReactApplication {
+
+  private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
+    /**
+     * Returns whether dev mode should be enabled.
+     * This enables e.g. the dev menu.
+     */
+    @Override
+    protected boolean getUseDeveloperSupport() {
+        return BuildConfig.DEBUG;
+    }
+
+    /**
+     * A list of packages used by the app. If the app uses additional views
+     * or modules besides the default ones, add more packages here.
+     */
+    @Override
+    protected List<ReactPackage> getPackages() {
+        return Arrays.<ReactPackage>asList(
+            new MainReactPackage(),
+            new VoicePackage()
+        );
+    }
+  };
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+      return mReactNativeHost;
+  }
+}

--- a/VoiceTest/package.json
+++ b/VoiceTest/package.json
@@ -1,13 +1,13 @@
 {
   "name": "VoiceTest",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start"
   },
   "dependencies": {
-    "react": "^0.14.8",
-    "react-native": "^0.25.1",
+    "react": "^15.3.2",
+    "react-native": "^0.34.1",
     "react-native-voice": "^0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "react-native-voice",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "React Native Native Voice library for iOS and Android",
   "main": "index.js",
   "author": "Sam Wenke <samwenke@gmail.com>",
   "peerDependencies": {
-    "react-native": "^0.14"
+    "react-native": ">=0.14 <0.35.0"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
Hi Sam,

I've worked through the issues of using your package with more recent version of React Native. The main issue is the `semver` for the 0th version essentially treats minors like majors (which with I disagree), because it means the rapidly updating RN will frequently break this without looser version requirements.  It was still compatible, but the `PeerDependencies` were broken so everything had to be updated.

In particular, updating to React Native 0.29+ required a slight restructuring of the Android example app, which I've done here. Much of the config is shifted form `MainActivity.java` to `MainApplication.java` because reasons.

No changes were made to core voice package internals.

~I'm not set up to compile and test for iOS, so that's the one gap remaining here for verification. If you (or anyone) pulled to check that, this PR could be updated as needed.~ 
_Edit: I missed that the README states only Android is supported anyways, so this is not an issue._
