### PR TITLE
Don't call into native destroy/cancel when not needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,13 +62,12 @@ class RCTVoice {
       return null;
     }
 
-    if (!this._loaded && !this._listeners) {
-      return Voice.cancelSpeech((error) => {
-        if (error) {
-          return error;
-        }
-        return null;
-      });
+    return Voice.cancelSpeech((error) => {
+      if (error) {
+        return error;
+      }
+      return null;
+    });
   }
   isAvailable(callback) {
     Voice.isSpeechAvailable(callback);

--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ class RCTVoice {
     };
   }
   destroy() {
+    if (!this._loaded && !this._listeners) {
+      return null;
+    }
+
     return Voice.destroySpeech((error) => {
       if (error) {
         return error;
@@ -54,12 +58,17 @@ class RCTVoice {
     });
   }
   cancel() {
-    return Voice.cancelSpeech((error) => {
-      if (error) {
-        return error;
-      }
+    if (!this._loaded && !this._listeners) {
       return null;
-    });
+    }
+
+    if (!this._loaded && !this._listeners) {
+      return Voice.cancelSpeech((error) => {
+        if (error) {
+          return error;
+        }
+        return null;
+      });
   }
   isAvailable(callback) {
     Voice.isSpeechAvailable(callback);


### PR DESCRIPTION
Calling `destroy()` or `stop()` will cause a `NullPointerExeception` crash if the voice module hasn't yet been initialized. I expected to be able to call `Voice.isRecognizing()` to check to prevent this, but on Android at least that method always seems to return false.

It would probably be a better solution to have `Voice.isRecognizing()` work, but I don't have the desire to dig into Java so here is my bandaid.