### PR TITLE
Changed the react-native dependency of android.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,5 +40,5 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.facebook.react:react-native:0.17.+'
+    compile 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Thank you for making the module first.

I had some trouble building on android because of the react-native dependency issue.
I think It would be better to change the value of `build.gradle`.