### PR TITLE
return a Promise from methods even if Voice was not started

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ class RCTVoice {
   }
   destroy() {
     if (!this._loaded && !this._listeners) {
-      return;
+      return Promise.resolve();
     }
     return new Promise((resolve, reject) => {
       Voice.destroySpeech((error) => {
@@ -77,7 +77,7 @@ class RCTVoice {
   }
   stop() {
     if (!this._loaded && !this._listeners) {
-      return;
+      return Promise.resolve();
     }
     return new Promise((resolve, reject) => {
       Voice.stopSpeech((error) => {
@@ -91,7 +91,7 @@ class RCTVoice {
   }
   cancel() {
     if (!this._loaded && !this._listeners) {
-      return;
+      return Promise.resolve();
     }
     return new Promise((resolve, reject) => {
       Voice.cancelSpeech((error) => {


### PR DESCRIPTION
Return an empty Promise from stop, destroy and cancel methods. It would be easier to call cleaning of listeners when voice has not been started before.

This fix avoids failing of Voice.destroy().then() when calling it on componentWillUnmount() and starting of the voice service is dependent on user's interaction.