### PR TITLE
Only set voiceEmitter const on ios or android to avoid resolution errors in web

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,11 @@ import React, {
 } from 'react-native';
 
 const { Voice } = NativeModules;
-const voiceEmitter = new NativeEventEmitter(Voice);
+
+// NativeEventEmitter is only availabe on React Native platforms, so this conditional is used to avoid import conflicts in the browser/server
+if (Platform.OS !== "web") {
+  const voiceEmitter = new NativeEventEmitter(Voice);
+}
 
 class RCTVoice {
   constructor() {


### PR DESCRIPTION
This is a tiny one but solves an annoying "Not a constructor" webpack resolution issue in the browser.

Thanks for building this!