### PR TITLE
Allow other audio players in the app to play nicely together!

### DIFF
--- a/ios/Voice/Voice.m
+++ b/ios/Voice/Voice.m
@@ -37,6 +37,9 @@
 
     NSError* audioSessionError = nil;
     self.audioSession = [AVAudioSession sharedInstance];
+    
+    // Allow other audio players in the app to play nicely together!
+    [self.audioSession setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionMixWithOthers error:nil];
 
     if (audioSessionError != nil) {
         [self sendResult:RCTMakeError([audioSessionError localizedDescription], nil, nil) :nil :nil :nil];


### PR DESCRIPTION
Allow other audio players in the app to play nicely together!

The problem is when you start recording, and another video player is ON. It'll crash.