### PR TITLE
Do not automatically tear down when run into error

### DIFF
--- a/ios/Voice/Voice.m
+++ b/ios/Voice/Voice.m
@@ -71,7 +71,6 @@
         if (error != nil) {
             NSString *errorMessage = [NSString stringWithFormat:@"%ld/%@", error.code, [error localizedDescription]];
             [self sendResult:RCTMakeError(errorMessage, nil, nil) :nil :nil :nil];
-            [self teardown];
             return;
         }
 


### PR DESCRIPTION
Avoid automatically tearing down when run into error. Error could occur when caller goes through a tearDown and restart sequence, When this happens, existing recognition task will receive error after tearDown is called and would call tearDown upon error while caller trying to restart the recognition again.

As Caller can decide to tear down on error anyway, so automatically tear down is not necessary here.