### PR TITLE
Fix Android integration issues

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,19 @@
 apply plugin: 'com.android.library'
 
+repositories {
+    mavenLocal()
+    jcenter()
+    maven {
+        // For developing the library outside the context of the example app, expect `react-native`
+        // to be installed at `./node_modules`.
+        url "$projectDir/../node_modules/react-native/android"
+    }
+    maven {
+        // For developing the example app.
+        url "$projectDir/../../react-native/android"
+    }
+}
+
 android {
     compileSdkVersion 23
     buildToolsVersion "23.0.2"

--- a/android/src/main/java/com/wenkesj/voice/VoiceModule.java
+++ b/android/src/main/java/com/wenkesj/voice/VoiceModule.java
@@ -11,7 +11,6 @@ import android.speech.SpeechRecognizer;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
-import com.facebook.react.ReactActivity;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -22,6 +21,7 @@ import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.modules.core.PermissionAwareActivity;
 import com.facebook.react.modules.core.PermissionListener;
 
 import java.util.ArrayList;
@@ -118,7 +118,7 @@ public class VoiceModule extends ReactContextBaseJavaModule implements Recogniti
     if (!isPermissionGranted() && opts.getBoolean("REQUEST_PERMISSIONS_AUTO")) {
       String[] PERMISSIONS = {Manifest.permission.RECORD_AUDIO};
       if (this.getCurrentActivity() != null) {
-        ((ReactActivity) this.getCurrentActivity()).requestPermissions(PERMISSIONS, 1, new PermissionListener() {
+        ((PermissionAwareActivity) this.getCurrentActivity()).requestPermissions(PERMISSIONS, 1, new PermissionListener() {
           public boolean onRequestPermissionsResult(final int requestCode,
                                                     @NonNull final String[] permissions,
                                                     @NonNull final int[] grantResults) {


### PR DESCRIPTION
1. Update `build.gradle` to reference `node_modules` when picking up react-native dependency (see https://github.com/ivpusic/react-native-image-crop-picker/pull/245 for detailed discussion of this issue)
2. When integrating react-native into an Android app that is based on fragments and not activities, there is a need to allow activities other than `ReactActivity` to use `VoiceModule`.  This change allows any activity that implements the `PermissionListener` interface to be used.