### PR TITLE
Adds Location and Speech Recognition usage descriptions

### DIFF
--- a/VoiceTest/ios/VoiceTest/Info.plist
+++ b/VoiceTest/ios/VoiceTest/Info.plist
@@ -39,7 +39,11 @@
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
+	<string>${PRODUCT_NAME} WhenInUse Location</string>
+	<key>NSMicrophoneUsageDescription</key>
+    <string>${PRODUCT_NAME} Microphone Usage</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+    <string>${PRODUCT_NAME} Speech Recognition Usage</string>
 	<key>NSAppTransportSecurity</key>
 	<!--See http://ste.vn/2015/06/10/configuring-app-transport-security-ios-9-osx-10-11/ -->
 	<dict>


### PR DESCRIPTION
Was able to get the VoiceTest app running but it crashed whenever the microphone icon was pressed. Xcode would show an error `dyld__abort_with_payload`. Some research led me to find that missing descriptions for hardware usage requests could be causing this. I added these and was able to get the app to start speech recognition without crashing.

Tested with React 16.4.1 and React Native 0.56.0.