### PR TITLE
Add getSpeechRecognitionServices and an option to explicitly specify the speech engine to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,15 +109,15 @@ class VoiceTest extends Component {
 
 **All methods _now_ return a `new Promise` for `async/await` compatibility.**
 
-Method Name                 | Description                                                                         | Platform
---------------------------- | ----------------------------------------------------------------------------------- | --------
-Voice.isAvailable()         | Checks whether a speech recognition service is available on the system.             | Android, iOS
-Voice.start(locale)         | Starts listening for speech for a specific locale. Returns null if no error occurs. | Android, iOS
-Voice.stop()                | Stops listening for speech. Returns null if no error occurs.                        | Android, iOS
-Voice.cancel()              | Cancels the speech recognition. Returns null if no error occurs.                    | Android, iOS
-Voice.destroy()             | Destroys the current SpeechRecognizer instance. Returns null if no error occurs.    | Android, iOS
-Voice.removeAllListeners()  | Cleans/nullifies overridden `Voice` static methods.                                 | Android, iOS
-Voice.isRecognizing()       | Return if the SpeechRecognizer is recognizing.                                      | Android, iOS
+Method Name                          | Description                                                                                                                                                             | Platform
+------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------
+Voice.isAvailable()                  | Checks whether a speech recognition service is available on the system.                                                                                                 | Android, iOS
+Voice.start(locale)                  | Starts listening for speech for a specific locale. Returns null if no error occurs.                                                                                     | Android, iOS
+Voice.stop()                         | Stops listening for speech. Returns null if no error occurs.                                                                                                            | Android, iOS
+Voice.cancel()                       | Cancels the speech recognition. Returns null if no error occurs.                                                                                                        | Android, iOS
+Voice.destroy()                      | Destroys the current SpeechRecognizer instance. Returns null if no error occurs.                                                                                        | Android, iOS
+Voice.removeAllListeners()           | Cleans/nullifies overridden `Voice` static methods.                                                                                                                     | Android, iOS
+Voice.isRecognizing()                | Return if the SpeechRecognizer is recognizing.                                                                                                                          | Android, iOS
 Voice.getSpeechRecognitionServices() | Returns a list of the speech recognition engines available on the device. (Example: `['com.google.android.googlequicksearchbox']` if Google is the only one available.) | Android
 <h2 align="center">Events</h2>
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Voice.cancel()              | Cancels the speech recognition. Returns null if no
 Voice.destroy()             | Destroys the current SpeechRecognizer instance. Returns null if no error occurs.    | Android, iOS
 Voice.removeAllListeners()  | Cleans/nullifies overridden `Voice` static methods.                                 | Android, iOS
 Voice.isRecognizing()       | Return if the SpeechRecognizer is recognizing.                                      | Android, iOS
-
+Voice.getSpeechRecognitionServices() | Returns a list of the speech recognition engines available on the device. (Example: `['com.google.android.googlequicksearchbox']` if Google is the only one available.) | Android
 <h2 align="center">Events</h2>
 
 <p align="center">Callbacks that are invoked when a native event emitted.</p>

--- a/android/src/main/java/com/wenkesj/voice/VoiceModule.java
+++ b/android/src/main/java/com/wenkesj/voice/VoiceModule.java
@@ -16,6 +16,7 @@ import android.util.Log;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -245,7 +246,7 @@ public class VoiceModule extends ReactContextBaseJavaModule implements Recogniti
   }
 
   @ReactMethod
-  public void getSpeechRecognitionServices(Callback callback) {
+  public void getSpeechRecognitionServices(Promise promise) {
     final List<ResolveInfo> services = this.reactContext.getPackageManager()
         .queryIntentServices(new Intent(RecognitionService.SERVICE_INTERFACE), 0);
     WritableArray serviceNames = Arguments.createArray();
@@ -253,7 +254,7 @@ public class VoiceModule extends ReactContextBaseJavaModule implements Recogniti
       serviceNames.pushString(service.serviceInfo.packageName);
     }
 
-    callback.invoke(serviceNames);
+    promise.resolve(serviceNames);
   }
 
   private boolean isPermissionGranted() {

--- a/src/index.js
+++ b/src/index.js
@@ -119,6 +119,18 @@ class RCTVoice {
       });
     });
   }
+
+  /**
+   * (Android) Get a list of the speech recognition engines available on the device
+   * */
+  getSpeechRecognitionServices() {
+    if (Platform.OS !== 'android') {
+      throw new Exception('Speech recognition services can be queried for only on Android');
+    }
+
+    return Voice.getSpeechRecognitionServices();
+  }
+
   isRecognizing() {
     return new Promise(resolve => {
       Voice.isRecognizing(isRecognizing => resolve(isRecognizing));


### PR DESCRIPTION
We had issues in our app when the user didn't have Google's engine installed and the device tried to use something like Samsung's instead. So we wrote this code to show an appropriate error message and offer suggestions to the user. Been using it in our app for a few months now, seems stable. (We had made changes off a fork of this repo, so I rebased and applied these commits on top of the upstream master). I think these could be helpful to someone else as well. And this is not a breaking change.