### PR TITLE
Allow configurable Android SDK versions from root project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,13 +14,18 @@ repositories {
     }
 }
 
+def DEFAULT_COMPILE_SDK_VERSION = 23
+def DEFAULT_BUILD_TOOLS_VERSION = "23.0.2"
+def DEFAULT_TARGET_SDK_VERSION = 23
+def DEFAULT_SUPPORT_LIB_VERSION = "23.1.1"
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 23
+        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"
     }
@@ -50,9 +55,11 @@ allprojects {
     }
 }
 
+def supportVersion = rootProject.hasProperty('supportLibVersion') ? rootProject.supportLibVersion : DEFAULT_SUPPORT_LIB_VERSION
+
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:appcompat-v7:${supportVersion}'
     compile 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
This allows the module the ability to inherit SDK versions from the root project.  Otherwise, compatibility will be broken if root project uses newer SDK versions