### PR TITLE
[issue 155: bluetooth earphone connection lost]

### DIFF
--- a/ios/Voice/Voice.m
+++ b/ios/Voice/Voice.m
@@ -52,7 +52,7 @@
 - (BOOL)isHeadsetPluggedIn {
     AVAudioSessionRouteDescription* route = [[AVAudioSession sharedInstance] currentRoute];
     for (AVAudioSessionPortDescription* desc in [route outputs]) {
-        if ([[desc portType] isEqualToString:AVAudioSessionPortHeadphones])
+        if ([[desc portType] isEqualToString:AVAudioSessionPortHeadphones] || [[desc portType] isEqualToString:AVAudioSessionPortBluetoothA2DP])
             return YES;
     }
     return NO;


### PR DESCRIPTION
[issue 155: bluetooth earphone connection lost]
related issue: https://github.com/wenkesj/react-native-voice/issues/155

the bluetooth earphone devices blow lost connection.

- [Plantronics M70](https://www.amazon.com/Plantronics-M70-Noise-Reducing-Bluetooth-Refurbished/dp/B00WAIQA7C/ref=sr_1_1_sspa?crid=3D54L8DN6T0Y3&keywords=plantronics+bluetooth+headset&qid=1551670895&s=gateway&sprefix=plantron%2Caps%2C278&sr=8-1-spons&psc=1)
- [Plantronics Voyager 5200 Wireless Bluetooth Headset](https://www.amazon.com/Plantronics-Voyager-Wireless-Bluetooth-Headset/dp/B01H2RBQUG/ref=sxin_2_osp18-a06b3a44_cov?ascsubtag=a06b3a44-d06b-4f48-9444-5a7bbe9750c1&creativeASIN=B01H2RBQUG&crid=3D54L8DN6T0Y3&cv_ct_id=amzn1.osp.a06b3a44-d06b-4f48-9444-5a7bbe9750c1&cv_ct_pg=search&cv_ct_wn=osp-search&keywords=plantronics+bluetooth+headset&linkCode=oas&pd_rd_i=B01H2RBQUG&pd_rd_r=63ff0aa8-efab-42c9-917c-6923df587298&pd_rd_w=r6oLB&pd_rd_wg=qeAIe&pf_rd_p=37dcfc87-cdc2-4138-941e-56f6d8e6b463&pf_rd_r=MQTT9PBA3C85YFNG3WJ9&qid=1551670895&s=gateway&sprefix=plantron%2Caps%2C278&tag=thewire06oa-20)

these devices are detected AVAudioSessionPortBluetoothA2DP in isHeadsetPluggedIn.