### PR TITLE
fix(ios): teardown on bridge reloading

### DIFF
--- a/ios/Voice/Voice.m
+++ b/ios/Voice/Voice.m
@@ -45,6 +45,8 @@
         [self sendResult:@{@"code": @"audio", @"message": [audioSessionError localizedDescription]} :nil :nil :nil];
         return NO;
     }
+
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(teardown) name:RCTBridgeWillReloadNotification object:nil];
     
     return YES;
 }


### PR DESCRIPTION
My app used to crash because `react-native-module` doesn't handle the reloading of the RN Bridge, which means that when the app reloads using the "Live Reload" functionality of RN the module tries to use the Bridge, which is not ready, and therefore it crashes.

In this PR we listen for the reloading of the bridge and we teardown the module with it so it can be reinitialized later on